### PR TITLE
Fix for gcc fpermissive error

### DIFF
--- a/src/vu8/Context.cpp
+++ b/src/vu8/Context.cpp
@@ -120,7 +120,7 @@ void Context::Init() {
 }
 
 void Context::Release() {
-    context_ = v8::Persistent<v8::Context>::Persistent();
+    context_ = v8::Persistent<v8::Context>();
 }
 
 void Context::RunFile(char const *filename) {


### PR DESCRIPTION
Error occurs on gcc 4.7.1 on linux.

vu8/src/vu8/Context.cpp: In member function 'void vu8::Context::Release()':
vu8/src/vu8/Context.cpp:123:56: error: cannot call constructor 'v8::Persistent<v8::Context>::Persistent' directly [-fpermissive]
vu8/src/vu8/Context.cpp:123:56: error:   for a function-style cast, remove the redundant '::Persistent' [-fpermissive]

Hope this all looks good.
